### PR TITLE
check for undefined prefix not falsy value

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function modulepreload({ index, prefix, shouldPreload = default
 
       const createLinkFromChunk = compose(
         createLinkElement(dom),
-        createLinkHref(prefix || dir),
+        createLinkHref((typeof prefix !== "undefined") ? prefix : dir),
         getPath,
       );
 


### PR DESCRIPTION
so you can set the prefix value to an empty string for root paths like /chunk-abc123.js